### PR TITLE
Ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+datagen.Rout
+gformula_zz.Rout


### PR DESCRIPTION
.gitignore is a special file in a git repository.  It contains a series of patterns for file names.  If git matches a filename to one of the patterns in .gitignore, git will not attempt to add those files to commits.